### PR TITLE
Feature/downsample map

### DIFF
--- a/config/mid360.yaml
+++ b/config/mid360.yaml
@@ -41,10 +41,11 @@
                             0., 0., 1.]
 
         publish:
-            rate: 10                     # Odometry publish rate [Hz, int]. Note that the odometry rate cannot exceed the lidar input rate.
+            rate: 10                     # Odometry publish rate [Hz, int]. Note that the odometry rate cannot exceed the lidar input rate.            
             path_en: true                # true: publish Path
             effect_map_en: false         # true: publish Effects
             map_en: true                 # true: publish Map cloud
+            map_pub_interval: 1.0        # Map publish interval in seconds
             scan_publish_en:  true       # false: close all the point cloud output
             dense_publish_en: false      # false: low down the points number in a global-frame point clouds scan.
             scan_bodyframe_pub_en: true  # true: output the point cloud scans in IMU-body-frame

--- a/config/mid360.yaml
+++ b/config/mid360.yaml
@@ -48,6 +48,7 @@
             scan_publish_en:  true       # false: close all the point cloud output
             dense_publish_en: false      # false: low down the points number in a global-frame point clouds scan.
             scan_bodyframe_pub_en: true  # true: output the point cloud scans in IMU-body-frame
+            map_voxelfilter_size: 0.3    # Apply an additional voxel filter to the map before publishing, to reduce the size of the map point cloud. 0.0 : no voxel filter applied
 
         pcd_save:
             pcd_save_en: true

--- a/config/ouster64.yaml
+++ b/config/ouster64.yaml
@@ -40,6 +40,7 @@
             scan_publish_en:  true       # false: close all the point cloud output
             dense_publish_en: true       # false: low down the points number in a global-frame point clouds scan.
             scan_bodyframe_pub_en: true  # true: output the point cloud scans in IMU-body-frame
+            map_voxelfilter_size: 0.3    # Apply an additional voxel filter to the map before publishing, to reduce the size of the map point cloud. 0.0 : no voxel filter applied
 
         pcd_save:
             pcd_save_en: true

--- a/src/laserMapping.cpp
+++ b/src/laserMapping.cpp
@@ -129,6 +129,7 @@ PointCloudXYZI::Ptr _featsArray;
 
 pcl::VoxelGrid<PointType> downSizeFilterSurf;
 pcl::VoxelGrid<PointType> downSizeFilterMap;
+pcl::VoxelGrid<PointType> mapPubVoxelFilter;
 
 KD_TREE<PointType> ikdtree;
 
@@ -542,8 +543,19 @@ void publish_map(rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr pub
     }
     *pcl_wait_pub += *laserCloudWorld;
 
+    // Apply additional voxel filter to downsample the map before publishing
     sensor_msgs::msg::PointCloud2 laserCloudmsg;
-    pcl::toROSMsg(*pcl_wait_pub, laserCloudmsg);
+    if (mapPubVoxelFilter.getLeafSize().x() != 0.0f)
+    {
+        PointCloudXYZI::Ptr pcl_wait_pub_filtered(new PointCloudXYZI());
+        mapPubVoxelFilter.setInputCloud(pcl_wait_pub);
+        mapPubVoxelFilter.filter(*pcl_wait_pub_filtered);
+        pcl::toROSMsg(*pcl_wait_pub_filtered, laserCloudmsg);
+    }
+    else
+    {
+        pcl::toROSMsg(*pcl_wait_pub, laserCloudmsg);
+    }
     // laserCloudmsg.header.stamp = ros::Time().fromSec(lidar_end_time);
     laserCloudmsg.header.stamp = get_ros_time(lidar_end_time);
     laserCloudmsg.header.frame_id = sensor_init_frame;
@@ -848,6 +860,7 @@ public:
         this->declare_parameter<bool>("publish.map_en", false);
         this->declare_parameter<bool>("publish.scan_publish_en", true);
         this->declare_parameter<bool>("publish.dense_publish_en", true);
+        this->declare_parameter<double>("publish.map_voxelfilter_size", 0.0);
         this->declare_parameter<bool>("publish.scan_bodyframe_pub_en", true);
         this->declare_parameter<int>("max_iteration", 4);
         this->declare_parameter<string>("map_file_path", "");
@@ -888,6 +901,7 @@ public:
         this->get_parameter_or<bool>("publish.path_en", path_en, true);
         this->get_parameter_or<bool>("publish.effect_map_en", effect_pub_en, false);
         this->get_parameter_or<bool>("publish.map_en", map_pub_en, false);
+        this->get_parameter_or<double>("publish.map_voxelfilter_size", map_voxel_filter_size, 0.0);
         this->get_parameter_or<bool>("publish.scan_publish_en", scan_pub_en, true);
         this->get_parameter_or<bool>("publish.dense_publish_en", dense_pub_en, true);
         this->get_parameter_or<bool>("publish.scan_bodyframe_pub_en", scan_body_pub_en, true);
@@ -899,7 +913,10 @@ public:
         this->get_parameter<string>("common.base_frame", base_frame);
         this->get_parameter<string>("common.lidar_frame", lidar_frame);
         this->get_parameter<string>("common.sensor_init_frame", sensor_init_frame);
-
+        if (map_voxel_filter_size == 0.0)
+            RCLCPP_INFO_STREAM(this->get_logger(), "Map voxel filter for publishing is disabled");
+        else
+            RCLCPP_INFO_STREAM(this->get_logger(), "Map voxel filter for publishing has leaf size: " << map_voxel_filter_size << std::endl);
         RCLCPP_INFO_STREAM(this->get_logger(), "Base Frame ID: " << base_frame);
         RCLCPP_INFO_STREAM(this->get_logger(), "Sensor Init Frame ID: " << sensor_init_frame);
         RCLCPP_INFO_STREAM(this->get_logger(), "Map Frame ID: " << map_frame);
@@ -950,6 +967,7 @@ public:
         memset(res_last, -1000.0f, sizeof(res_last));
         downSizeFilterSurf.setLeafSize(filter_size_surf_min, filter_size_surf_min, filter_size_surf_min);
         downSizeFilterMap.setLeafSize(filter_size_map_min, filter_size_map_min, filter_size_map_min);
+        mapPubVoxelFilter.setLeafSize(map_voxel_filter_size, map_voxel_filter_size, map_voxel_filter_size);
         memset(point_selected_surf, true, sizeof(point_selected_surf));
         memset(res_last, -1000.0f, sizeof(res_last));
 
@@ -1307,6 +1325,7 @@ private:
     double deltaT, deltaR, aver_time_consu = 0, aver_time_icp = 0, aver_time_match = 0, aver_time_incre = 0, aver_time_solve = 0, aver_time_const_H_time = 0;
     bool flg_EKF_converged, EKF_stop_flg = 0;
     double epsi[23] = {0.001};
+    double map_voxel_filter_size = 0.5;
 
     FILE *fp;
     ofstream fout_pre, fout_out, fout_dbg;

--- a/src/laserMapping.cpp
+++ b/src/laserMapping.cpp
@@ -858,6 +858,7 @@ public:
         this->declare_parameter<bool>("publish.path_en", true);
         this->declare_parameter<bool>("publish.effect_map_en", false);
         this->declare_parameter<bool>("publish.map_en", false);
+        this->declare_parameter<double>("publish.map_pub_interval", 1.0);
         this->declare_parameter<bool>("publish.scan_publish_en", true);
         this->declare_parameter<bool>("publish.dense_publish_en", true);
         this->declare_parameter<double>("publish.map_voxelfilter_size", 0.0);
@@ -901,6 +902,7 @@ public:
         this->get_parameter_or<bool>("publish.path_en", path_en, true);
         this->get_parameter_or<bool>("publish.effect_map_en", effect_pub_en, false);
         this->get_parameter_or<bool>("publish.map_en", map_pub_en, false);
+        this->get_parameter_or<double>("publish.map_pub_interval", map_pub_interval, 1.0);
         this->get_parameter_or<double>("publish.map_voxelfilter_size", map_voxel_filter_size, 0.0);
         this->get_parameter_or<bool>("publish.scan_publish_en", scan_pub_en, true);
         this->get_parameter_or<bool>("publish.dense_publish_en", dense_pub_en, true);
@@ -1027,7 +1029,7 @@ public:
         auto period_ms = std::chrono::milliseconds(static_cast<int64_t>(1000 / pub_rate)); // Hz to ms
         timer_ = rclcpp::create_timer(this, this->get_clock(), period_ms, std::bind(&LaserMappingNode::timer_callback, this));
 
-        auto map_period_ms = std::chrono::milliseconds(static_cast<int64_t>(1000.0));
+        auto map_period_ms = std::chrono::milliseconds(static_cast<int64_t>(map_pub_interval * 1000));
         map_pub_timer_ = rclcpp::create_timer(this, this->get_clock(), map_period_ms, std::bind(&LaserMappingNode::map_publish_callback, this));
         diagnostics_pub_timer_ = this->create_wall_timer(std::chrono::milliseconds(500), std::bind(&LaserMappingNode::diagnostics_callback, this));
 
@@ -1325,7 +1327,7 @@ private:
     double deltaT, deltaR, aver_time_consu = 0, aver_time_icp = 0, aver_time_match = 0, aver_time_incre = 0, aver_time_solve = 0, aver_time_const_H_time = 0;
     bool flg_EKF_converged, EKF_stop_flg = 0;
     double epsi[23] = {0.001};
-    double map_voxel_filter_size = 0.5;
+    double map_voxel_filter_size = 0.5, map_pub_interval = 1.0;
 
     FILE *fp;
     ofstream fout_pre, fout_out, fout_dbg;

--- a/src/laserMapping.cpp
+++ b/src/laserMapping.cpp
@@ -545,7 +545,7 @@ void publish_map(rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr pub
 
     // Apply additional voxel filter to downsample the map before publishing
     sensor_msgs::msg::PointCloud2 laserCloudmsg;
-    if (mapPubVoxelFilter.getLeafSize().x() != 0.0f)
+    if (mapPubVoxelFilter.getLeafSize().x() > 0.0f)
     {
         PointCloudXYZI::Ptr pcl_wait_pub_filtered(new PointCloudXYZI());
         mapPubVoxelFilter.setInputCloud(pcl_wait_pub);
@@ -915,7 +915,7 @@ public:
         this->get_parameter<string>("common.base_frame", base_frame);
         this->get_parameter<string>("common.lidar_frame", lidar_frame);
         this->get_parameter<string>("common.sensor_init_frame", sensor_init_frame);
-        if (map_voxel_filter_size == 0.0)
+        if (map_voxel_filter_size <= 0.0)
             RCLCPP_INFO_STREAM(this->get_logger(), "Map voxel filter for publishing is disabled");
         else
             RCLCPP_INFO_STREAM(this->get_logger(), "Map voxel filter for publishing has leaf size: " << map_voxel_filter_size << std::endl);


### PR DESCRIPTION
This applies a downsample filter to the map cloud before publishing (affects only the published cloud, not the one stored internally).
The filter leaf size and publishing interval can be set as parameters.